### PR TITLE
Removed extra "encryptable"

### DIFF
--- a/rootdir/fstab.mt6735
+++ b/rootdir/fstab.mt6735
@@ -6,7 +6,7 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/system     /system      ext4   ro                                                         wait
-/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata   /data        ext4   noatime,nosuid,nodev,noauto_da_alloc,discard               wait,check,resize,encryptable=encryptable=/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/metadata
+/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/userdata   /data        ext4   noatime,nosuid,nodev,noauto_da_alloc,discard               wait,check,resize,encryptable=/dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/metadata
 /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/cache      /cache       ext4   noatime,nosuid,nodev,noauto_da_alloc,discard               wait,check
 /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/protect1   /protect_f   ext4   noatime,nosuid,nodev,noauto_da_alloc,commit=1,nodelalloc   wait,check,autoformat
 /dev/block/platform/mtk-msdc.0/11230000.msdc0/by-name/protect2   /protect_s   ext4   noatime,nosuid,nodev,noauto_da_alloc,commit=1,nodelalloc   wait,check,autoformat


### PR DESCRIPTION
Without this change encrypting the phone hangs at 00:00 remaining.

I've only tested this by manually modifying the boot.img.